### PR TITLE
Add XCTest to sdk_frameworks.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -29,6 +29,7 @@ strict_warnings_objc_library(
     ]),
     enable_modules = 1,
     includes = ["src"],
+    sdk_frameworks = ["XCTest"],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
XCTest framework was missing from the MDFTesting bazel target.